### PR TITLE
feat(logs): add logging for CStaticStorage

### DIFF
--- a/OpenFK/DebugWindow.Designer.cs
+++ b/OpenFK/DebugWindow.Designer.cs
@@ -64,6 +64,8 @@ namespace OpenFK
             this.NetworkPostLogs = new System.Windows.Forms.RichTextBox();
             this.NetworkCommandTab = new System.Windows.Forms.TabPage();
             this.NetworkCommandLogs = new System.Windows.Forms.RichTextBox();
+            this.staticStorageTab = new System.Windows.Forms.TabPage();
+            this.staticStorageLogs = new System.Windows.Forms.RichTextBox();
             this.tabControl1.SuspendLayout();
             this.logTab.SuspendLayout();
             this.FileLogsTab.SuspendLayout();
@@ -84,6 +86,7 @@ namespace OpenFK
             this.NetworkGetTab.SuspendLayout();
             this.NetworkPostTab.SuspendLayout();
             this.NetworkCommandTab.SuspendLayout();
+            this.staticStorageTab.SuspendLayout();
             this.SuspendLayout();
             // 
             // generalLogs
@@ -104,6 +107,7 @@ namespace OpenFK
             this.tabControl1.Controls.Add(this.outgoing);
             this.tabControl1.Controls.Add(this.CLogger);
             this.tabControl1.Controls.Add(this.network);
+            this.tabControl1.Controls.Add(this.staticStorageTab);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
@@ -460,6 +464,26 @@ namespace OpenFK
             this.NetworkCommandLogs.TabIndex = 2;
             this.NetworkCommandLogs.Text = "";
             // 
+            // staticStorageTab
+            // 
+            this.staticStorageTab.Controls.Add(this.staticStorageLogs);
+            this.staticStorageTab.Location = new System.Drawing.Point(4, 22);
+            this.staticStorageTab.Name = "staticStorageTab";
+            this.staticStorageTab.Size = new System.Drawing.Size(599, 429);
+            this.staticStorageTab.TabIndex = 7;
+            this.staticStorageTab.Text = "CStaticStorage";
+            this.staticStorageTab.UseVisualStyleBackColor = true;
+            // 
+            // staticStorageLogs
+            // 
+            this.staticStorageLogs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.staticStorageLogs.Location = new System.Drawing.Point(0, 0);
+            this.staticStorageLogs.Name = "staticStorageLogs";
+            this.staticStorageLogs.ReadOnly = true;
+            this.staticStorageLogs.Size = new System.Drawing.Size(599, 429);
+            this.staticStorageLogs.TabIndex = 0;
+            this.staticStorageLogs.Text = "";
+            // 
             // DebugWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -488,6 +512,7 @@ namespace OpenFK
             this.NetworkGetTab.ResumeLayout(false);
             this.NetworkPostTab.ResumeLayout(false);
             this.NetworkCommandTab.ResumeLayout(false);
+            this.staticStorageTab.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -529,5 +554,7 @@ namespace OpenFK
         private System.Windows.Forms.RichTextBox NetworkPostLogs;
         private System.Windows.Forms.TabPage NetworkCommandTab;
         private System.Windows.Forms.RichTextBox NetworkCommandLogs;
+        private System.Windows.Forms.TabPage staticStorageTab;
+        private System.Windows.Forms.RichTextBox staticStorageLogs;
     }
 }

--- a/OpenFK/DebugWindow.cs
+++ b/OpenFK/DebugWindow.cs
@@ -40,6 +40,8 @@ namespace OpenFK
                 { "POST", NetworkPostLogs },
                 { "NetCommand", NetworkCommandLogs }
             };
+
+            LogManager.staticStorageLogs = staticStorageLogs;
         }
     }
 }

--- a/OpenFK/Form1.cs
+++ b/OpenFK/Form1.cs
@@ -432,7 +432,7 @@ namespace OpenFK
                         File.WriteAllBytes(Directory.GetCurrentDirectory() + @"\data\" + foldername + @"\" + filename + ".rdf", iso_8859_1.GetBytes(RDFTool.encode(iso_8859_1.GetString(RDFData))));
                     }
                     else File.WriteAllText(Directory.GetCurrentDirectory() + @"\data\" + foldername + @"\" + filename + ".xml", output.ToString()); //saves
-                    LogManager.LogFile("[Save] Successfully saved - " + foldername + "/" + filename); //Debug Output
+                    LogManager.LogFile($"[Save] [Success] {foldername}/{filename}");
                 }
             }
 
@@ -522,7 +522,7 @@ namespace OpenFK
                     var updateprocess = Process.Start(updatescript);
                 }
                 Application.Exit(); //Closes OpenFK
-                LogManager.LogGeneral("[OpenFK] Radicaclose was called"); //Debug output
+                LogManager.LogGeneral("[OpenFK] Radicaclose was called");
             }
 
             //
@@ -789,7 +789,7 @@ namespace OpenFK
                         File.WriteAllBytes(Directory.GetCurrentDirectory() + @"\data\" + "system" + @"\" + "users" + ".rdf", iso_8859_1.GetBytes(RDFTool.encode(iso_8859_1.GetString(RDFData))));
                     }
                     else File.WriteAllText(Directory.GetCurrentDirectory() + @"\data\" + "system" + @"\" + "users" + ".xml", data2send.ToString()); //saves
-                    LogManager.LogFile("[UserAdd] Successfully added user - " + username); //Debug Output
+                    LogManager.LogFile("[UserAdd] [Succes] " + username);
                 }
             }
 
@@ -931,7 +931,7 @@ namespace OpenFK
                 index = @"<commands><load section=""" + file + @""" name=""" + folder + @""" result=""1"" reason=""Error loading file!"" /></commands>"; //I would just let dotNET handle this, but UGLevels needs an error to continue.
             }
             setVar(index.ToString()); //Sends XML data to the game
-            LogManager.LogFile("[Load] Successfully loaded - " + folder + "/" + file); //Debug Output
+            LogManager.LogFile($"[Load] [Success] {folder}/{file}");
         }
 
         //

--- a/OpenFK/OFK.Common/LogManager.cs
+++ b/OpenFK/OFK.Common/LogManager.cs
@@ -16,6 +16,7 @@ namespace OpenFK.OFK.Common
         public static RichTextBox outgoingLogs;
         public static Dictionary<string, RichTextBox> CLogger;
         public static Dictionary<string, RichTextBox> networkLogs;
+        public static RichTextBox staticStorageLogs;
 
         private static void AppendLine(RichTextBox richTextBox, string message)
         {
@@ -65,6 +66,25 @@ namespace OpenFK.OFK.Common
             AppendLine(networkLogs[method], message);
             AppendLine(networkLogs["All"], message);
             LogGeneral($"[Network] {message}");
+        }
+
+        //TODO: implement table view to keep track of values like the localstorage viewer in devtools
+        public static void LogStaticStorageSet(string key, string oldValue, string newValue)
+        {
+            string message = $"[Set] {key} = {oldValue} --> {newValue}";
+            AppendLine(staticStorageLogs, message);
+        }
+
+        public static void LogStaticStorageGet(string key, string value, string defaultValue)
+        {
+            string message = $"[Get] {key} = {value} || {defaultValue}";
+            AppendLine(staticStorageLogs, message);
+        }
+
+        public static void LogStaticStorageDelete(string key, string oldValue)
+        {
+            string message = $"[Delete] {key} = {oldValue}";
+            AppendLine(staticStorageLogs, message);
         }
     }
 }


### PR DESCRIPTION
A log currently looks like this (didn't change in this PR) : `<log type="trace">some log here</log>`

New in this PR: logging for CStaticStorage, which looks like this:
Get: `<commands><staticstorage type="get" key="APP_ROOT" value="_level0" defaultvalue="if the specified key doesn't exist the get function will return this value instead" /></commands>`
Set: `<commands><staticstorage type="set" key="PATH_ZONE" value="zones/" original="the previous value" /></commands>`
Delete: `<commands><staticstorage type="delete" key="PATH_ZONE" original="the value before it was deleted" /></commands>`

The implementation in the SWF involves creating a new instance of `XML` and escaping a bunch of user input, before using `CCommunicator` to send it, this is why it's wrapped with the `commands` tag.

I released my implementation in the #mod-releases channel in the discord server. Link to the file below.
This implementation *only* has the `CLogger` and `CStaticStorage` things, it doesn't modify anything else, unlike your original mod which changed `CLogger`'s out handlers (this is to prevent unexpected things from happening).
[Access Internal Logs.swf](https://cdn.discordapp.com/attachments/465620893247340544/1144024944469102715/Access_Internal_Logs.swf)

I have some plans to use the current functionality to create a table view of the current state of the storage, similar to the `LocalStorage` inspector in devtools.

I also removed the `//Debug output` comment since it's pretty clear `LogManager` is for debugging purposes and changed some log messages for better readability in the logs.